### PR TITLE
h2 headers not h3 headers

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,14 +11,14 @@ navigation_weight: 1
 
 Expound the solution ...
 
-### The Code
+## The Code
 
 Highlight the code ...
 
-### Summation
+## Summation
 
 Delineate the steps ...
 
-### Live
+## Live
 
 Render the code live

--- a/docs/pages/target-blank.md
+++ b/docs/pages/target-blank.md
@@ -15,7 +15,7 @@ From your GitHub Flavored Markdown, or **GFM** `(.md)` page ...
 
 Append your `(.md)` external link with the `{:target="_blank"}` kramdown statement, as follows:
 
-### The Code
+## The Code
 
 ```liquid
 {% raw %}
@@ -23,7 +23,7 @@ Append your `(.md)` external link with the `{:target="_blank"}` kramdown stateme
 {% endraw %}
 ```
 
-### Summation
+## Summation
 
 The components of a successful external link in markdown are, as follows:
 
@@ -31,6 +31,6 @@ The components of a successful external link in markdown are, as follows:
 - Followed by, the complete URI for the targeted destination enveloped in a single set of parenthesis characters `(...)`, and
 - Thirdly, the given kramdown statement
 
-### Live
+## Live
 
 [temporarily disable liquid tag processing](https://shopify.github.io/liquid/tags/raw/){:target="_blank"}


### PR DESCRIPTION
Subtitles look better w h2 headers; h3 headers too small; only (1) one
h1 header allowed w auto standard hard return